### PR TITLE
Bugfix/value-id

### DIFF
--- a/lib/enumerations/base.rb
+++ b/lib/enumerations/base.rb
@@ -26,7 +26,7 @@ module Enumeration
       fail "Duplicate id #{attributes[:id]}" if find(attributes[:id])
 
       self._values = _values.merge(symbol => Enumeration::Value.new(self, symbol, attributes))
-      self._symbol_index = _symbol_index.merge(symbol => id)
+      self._symbol_index = _symbol_index.merge(symbol => attributes[:id])
 
       # Adds name base finder methods
       #

--- a/test/base_test.rb
+++ b/test/base_test.rb
@@ -1,6 +1,6 @@
 require_relative 'test_helper'
 
-class BaseTest < Test::Unit::TestCase
+class BaseTest < Minitest::Test
   def test_lookup_by_symbol
     status = Status.find(:draft)
 
@@ -10,7 +10,7 @@ class BaseTest < Test::Unit::TestCase
   def test_lookup_fail_by_symbol
     status = Status.find(:draft)
 
-    assert_not_equal :published, status.symbol
+    refute_same :published, status.symbol
   end
 
   def test_all
@@ -21,14 +21,14 @@ class BaseTest < Test::Unit::TestCase
   end
 
   def test_duplicated_id
-    assert_raise 'Duplicate id 1' do
+    assert_raises 'Duplicate id 1' do
       Class.new.values draft: { id: 1, name: 'Draft' },
                        test:  { id: 1, name: 'Draft' }
     end
   end
 
   def test_duplicated_symbol
-    assert_raise 'Duplicate symbol draft' do
+    assert_raises 'Duplicate symbol draft' do
       obj = Class.new
 
       obj.value :draft, id: 1, name: 'Draft'
@@ -39,7 +39,7 @@ class BaseTest < Test::Unit::TestCase
   def test_all_has_custom_attributes
     statuses = Status.all
 
-    assert_nothing_raised NoMethodError do
+    assert_silent do
       statuses.map(&:visible)
       statuses.map(&:deleted)
     end

--- a/test/enumerations_test.rb
+++ b/test/enumerations_test.rb
@@ -1,6 +1,6 @@
 require File.expand_path(File.dirname(__FILE__) + '/test_helper')
 
-class EnumerationsTest < Test::Unit::TestCase
+class EnumerationsTest < Minitest::Test
   def test_reflect_on_all_enumerations
     enumerations = Post.reflect_on_all_enumerations
 

--- a/test/reflection_test.rb
+++ b/test/reflection_test.rb
@@ -1,6 +1,6 @@
 require_relative 'test_helper'
 
-class ReflectionTest < Test::Unit::TestCase
+class ReflectionTest < Minitest::Test
   def test_reflections
     reflection = Enumeration::Reflection.new(:role, class_name: 'Role', foreign_key: :role_id)
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,5 +1,5 @@
 # TODO: improve tests
-require 'test/unit'
+require 'minitest/autorun'
 require 'enumerations'
 
 # Faking ActiveRecord

--- a/test/value_test.rb
+++ b/test/value_test.rb
@@ -1,6 +1,6 @@
 require_relative 'test_helper'
 
-class ValueTest < Test::Unit::TestCase
+class ValueTest < Minitest::Test
   def test_equal_by_id
     status = Status.find(:draft)
 

--- a/test/version_test.rb
+++ b/test/version_test.rb
@@ -1,6 +1,6 @@
 require_relative 'test_helper'
 
-class VersionTest < Test::Unit::TestCase
+class VersionTest < Minitest::Test
   def test_version
     assert_equal '1.1.0', Enumeration::VERSION
   end


### PR DESCRIPTION
id method was not defined and it raised an error 'NameError: undefined local variable or method `id' for Language:Class'.