### PR TITLE
String based IDs

### DIFF
--- a/lib/enumerations/finder_methods.rb
+++ b/lib/enumerations/finder_methods.rb
@@ -12,7 +12,7 @@ module Enumerations
     def find(key)
       case key
       when Symbol then find_by_key(key)
-      when String then find_by_id(key) ? find_by_id(key) : find_by_key(key.to_sym)
+      when String then key.to_i > 0 ? find_by_id(key.to_i) : find_by_key(key.to_sym) || find_by_id(key)
       when Fixnum then find_by_id(key)
       end
     end

--- a/lib/enumerations/finder_methods.rb
+++ b/lib/enumerations/finder_methods.rb
@@ -12,7 +12,7 @@ module Enumerations
     def find(key)
       case key
       when Symbol then find_by_key(key)
-      when String then find_by_key(key.to_sym) || find_by_id(key.to_i)
+      when String then find_by_id(key) ? find_by_id(key) : find_by_key(key.to_sym)
       when Fixnum then find_by_id(key)
       end
     end

--- a/test/finder_test.rb
+++ b/test/finder_test.rb
@@ -13,7 +13,7 @@ class FinderTest < Minitest::Test
     refute_same :published, status.symbol
   end
 
-  def test_lookup_by_string_id
+  def test_lookup_by_fixnum_as_string_id
     status = Status.find('1')
 
     assert_equal :draft, status.symbol
@@ -67,5 +67,17 @@ class FinderTest < Minitest::Test
     roles = Role.where(description1: false)
 
     assert_equal [], roles
+  end
+
+  def test_lookup_by_string_id
+    pos = Position.find('PRES')
+    
+    assert_equal :president, pos.symbol
+  end
+
+  def test_where_by_string_id
+    pos = Position.where(id: 'PRES')
+  
+    assert_equal 1, pos.count
   end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -28,6 +28,11 @@ class Role < Enumerations::Base
   end
 end
 
+class Position < Enumerations::Base
+  value :president, id: 'PRES', name: 'President'
+  value :vp, id: 'VP', name: 'Vice President'
+end
+
 class Post < ActiveRecord::Base
   attr_accessor :status_id, :some_other_status_id
 


### PR DESCRIPTION
Adjust finder methods so ids that are actually strings will work as well - to support older database schema with string-based value objects embedded in it.  For example:

Document.document_type_code -> 4 char varchar.  Build an enumeration like this:

value :book, id: 'BOOK', name: 'Book'
value :magazine, id: 'MAG', name: 'Magazine'
value :article, id; 'JRNL', name: 'Journal Article'

find('JRNL') returns nil, as JRNL isn't a value - its the id.