### PR TITLE
Fix giving invalid enum name raises error

### DIFF
--- a/lib/enumerations.rb
+++ b/lib/enumerations.rb
@@ -7,6 +7,7 @@ require 'enumerations/configuration'
 require 'enumerations/version'
 require 'enumerations/base'
 require 'enumerations/reflection'
+require 'enumerations/enumerations_error'
 
 module Enumerations
   extend ActiveSupport::Concern
@@ -84,10 +85,14 @@ module Enumerations
     def define_setter_method(reflection)
       define_method("#{reflection.name}=") do |other|
         enumeration_value = reflection.enumerator_class.find(other)
-        raise "invalid value assignment for #{reflection.foreign_key}" if enumeration_value.nil?
+
+        if enumeration_value.nil? && !other.nil?
+          raise EnumerationsError,
+            "invalid value assignment for #{reflection.foreign_key} (#{other.to_s})"
+        end
 
         self[reflection.foreign_key] =
-          enumeration_value.send(Enumerations.configuration.primary_key || :symbol)
+          other && enumeration_value.send(Enumerations.configuration.primary_key || :symbol)
       end
     end
 

--- a/lib/enumerations.rb
+++ b/lib/enumerations.rb
@@ -86,13 +86,9 @@ module Enumerations
       define_method("#{reflection.name}=") do |other|
         enumeration_value = reflection.enumerator_class.find(other)
 
-        if enumeration_value.nil? && !other.nil?
-          raise EnumerationsError,
-            "invalid value assignment for #{reflection.foreign_key} (#{other.to_s})"
-        end
-
         self[reflection.foreign_key] =
-          other && enumeration_value.send(Enumerations.configuration.primary_key || :symbol)
+          enumeration_value &&
+          enumeration_value.send(Enumerations.configuration.primary_key || :symbol)
       end
     end
 

--- a/lib/enumerations.rb
+++ b/lib/enumerations.rb
@@ -84,6 +84,7 @@ module Enumerations
     def define_setter_method(reflection)
       define_method("#{reflection.name}=") do |other|
         enumeration_value = reflection.enumerator_class.find(other)
+        raise "invalid value assignment for #{reflection.foreign_key}" if enumeration_value.nil?
 
         self[reflection.foreign_key] =
           enumeration_value.send(Enumerations.configuration.primary_key || :symbol)

--- a/lib/enumerations/base.rb
+++ b/lib/enumerations/base.rb
@@ -80,13 +80,13 @@ module Enumerations
     end
 
     def self.validate_symbol_and_primary_key(symbol, attributes)
-      raise "Duplicate symbol #{symbol}" if find(symbol)
+      raise EnumerationsError, "Duplicate symbol #{symbol}" if find(symbol)
 
       primary_key = Enumerations.configuration.primary_key
       return if primary_key.nil?
 
-      raise 'Enumeration primary key is required' if attributes[primary_key].nil?
-      raise "Duplicate primary key #{attributes[primary_key]}" if find(attributes[primary_key])
+      raise EnumerationsError, 'Enumeration primary key is required' if attributes[primary_key].nil?
+      raise EnumerationsError, "Duplicate primary key #{attributes[primary_key]}" if find(attributes[primary_key])
 
       self._symbol_index = _symbol_index.merge(symbol => attributes[primary_key])
     end

--- a/lib/enumerations/enumerations_error.rb
+++ b/lib/enumerations/enumerations_error.rb
@@ -1,0 +1,2 @@
+class EnumerationsError < RuntimeError
+end

--- a/test/base_test.rb
+++ b/test/base_test.rb
@@ -16,7 +16,7 @@ class BaseTest < Minitest::Test
   end
 
   def test_duplicated_symbol
-    assert_raises 'Duplicate symbol draft' do
+    assert_raises EnumerationsError, 'Duplicate symbol draft' do
       obj = Class.new(Enumerations::Base)
 
       obj.value :draft, id: 1, name: 'Draft'

--- a/test/configuration_test.rb
+++ b/test/configuration_test.rb
@@ -37,15 +37,15 @@ class ConfigurationTest < Minitest::Test
   def test_required_primary_key_when_primary_key_configured
     Enumerations.configure { |config| config.primary_key = :id }
 
-    assert_raises 'Enumeration primary key is required' do
-      Class.new(Enumerations::Base).value draft: { name: 'Draft' }
+    assert_raises EnumerationsError, 'Enumeration primary key is required' do
+      Class.new(Enumerations::Base).value :draft, name: 'Draft'
     end
   end
 
   def test_duplicated_primary_key_when_primary_key_configured
     Enumerations.configure { |config| config.primary_key = :id }
 
-    assert_raises 'Duplicate primary key 1' do
+    assert_raises EnumerationsError, 'Duplicate primary key 1' do
       Class.new(Enumerations::Base).values draft: { id: 1, name: 'Draft' },
                                            test:  { id: 1, name: 'Draft' }
     end

--- a/test/enumerations_test.rb
+++ b/test/enumerations_test.rb
@@ -87,14 +87,12 @@ class EnumerationsTest < Minitest::Test
     assert_equal query_hash, role: :admin
   end
 
-  def test_raising_error_on_nonexistent_value_assignment
-    exception = assert_raises EnumerationsError do
-      User.new(role: :nonexistent_value)
-    end
-    assert_equal 'invalid value assignment for role (nonexistent_value)', exception.message
+  def test_nonexistent_value_assignment
+    user = User.new(role: :nonexistent_value)
+    assert_nil user.role
   end
 
-  def test_raising_error_on_nil_value_assignment
+  def test_on_nil_value_assignment
     user = User.new(role: nil)
     assert_nil user.role
   end

--- a/test/enumerations_test.rb
+++ b/test/enumerations_test.rb
@@ -85,4 +85,18 @@ class EnumerationsTest < Minitest::Test
 
     assert_equal query_hash, role: :admin
   end
+
+  def test_raising_error_on_nonexistent_value_assignment
+    exception = assert_raises RuntimeError do
+      User.new(role: :nonexistent_value)
+    end
+    assert_equal 'invalid value assignment for role', exception.message
+  end
+
+  def test_raising_error_on_nil_value_assignment
+    exception = assert_raises RuntimeError do
+      User.new(role: nil)
+    end
+    assert_equal 'invalid value assignment for role', exception.message
+  end
 end

--- a/test/enumerations_test.rb
+++ b/test/enumerations_test.rb
@@ -1,4 +1,5 @@
 require_relative 'helpers/test_helper'
+require 'enumerations/enumerations_error'
 
 class EnumerationsTest < Minitest::Test
   def test_reflect_on_all_enumerations
@@ -87,16 +88,14 @@ class EnumerationsTest < Minitest::Test
   end
 
   def test_raising_error_on_nonexistent_value_assignment
-    exception = assert_raises RuntimeError do
+    exception = assert_raises EnumerationsError do
       User.new(role: :nonexistent_value)
     end
-    assert_equal 'invalid value assignment for role', exception.message
+    assert_equal 'invalid value assignment for role (nonexistent_value)', exception.message
   end
 
   def test_raising_error_on_nil_value_assignment
-    exception = assert_raises RuntimeError do
-      User.new(role: nil)
-    end
-    assert_equal 'invalid value assignment for role', exception.message
+    user = User.new(role: nil)
+    assert_nil user.role
   end
 end

--- a/test/enumerations_test.rb
+++ b/test/enumerations_test.rb
@@ -75,8 +75,8 @@ class EnumerationsTest < Minitest::Test
   end
 
   def test_enumerated_class_has_scopes
-    Role.all do |role|
-      assert_respond_to User, ['with_role', role.name].join('_').to_sym
+    Role.all.each do |role|
+      assert_respond_to User, ['with_role', role.to_s].join('_').to_sym
     end
   end
 


### PR DESCRIPTION
- Check if enum name is invalid before assignment
- Add tests for assigning invalid enum names
- Fix testing enumerated class scopes

Resolves #21: Error when assiging nil and #23: Giving a invalid enum name raises an error.