### PR TITLE
Feature/translation configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -265,7 +265,7 @@ Status.other.name?                             # => false
 Translations
 =====
 
-**Enumerations** uses power of I18n API (if trnslate configuration is set to true) to enable you to create a locale file
+**Enumerations** uses power of I18n API (if translate_attributes configuration is set to true) to enable you to create a locale file
 for enumerations like this:
 
 ```yaml
@@ -307,9 +307,9 @@ Example of configuration:
 # config/initializers/enumerations.rb
 
 Enumerations.configure do |config|
-  config.primary_key        = :id
-  config.foreign_key_suffix = :id
-  config.translate          = true
+  config.primary_key          = :id
+  config.foreign_key_suffix   = :id
+  config.translate_attributes = true
 end
 ```
 

--- a/README.md
+++ b/README.md
@@ -265,7 +265,7 @@ Status.other.name?                             # => false
 Translations
 =====
 
-**Enumerations** uses power of I18n API to enable you to create a locale file
+**Enumerations** uses power of I18n API (if trnslate configuration is set to true) to enable you to create a locale file
 for enumerations like this:
 
 ```yaml
@@ -309,6 +309,7 @@ Example of configuration:
 Enumerations.configure do |config|
   config.primary_key        = :id
   config.foreign_key_suffix = :id
+  config.translate          = true
 end
 ```
 

--- a/enumerations.gemspec
+++ b/enumerations.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'pry-byebug'
   s.add_development_dependency 'rake'
   s.add_development_dependency 'simplecov'
-  s.add_development_dependency 'sqlite3', '~> 1.3.6'
+  s.add_development_dependency 'sqlite3', '~> 1.4.0'
 
   s.files         = `git ls-files`.split("\n")
   s.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")

--- a/lib/enumerations/configuration.rb
+++ b/lib/enumerations/configuration.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Enumerations
   def self.configuration
     @configuration ||= Configuration.new
@@ -14,12 +16,12 @@ module Enumerations
   class Configuration
     attr_accessor :primary_key
     attr_accessor :foreign_key_suffix
-    attr_accessor :translate
+    attr_accessor :translate_attributes
 
     def initialize
-      @primary_key        = nil
-      @foreign_key_suffix = nil
-      @translate          = true
+      @primary_key          = nil
+      @foreign_key_suffix   = nil
+      @translate_attributes = true
     end
   end
 end

--- a/lib/enumerations/configuration.rb
+++ b/lib/enumerations/configuration.rb
@@ -14,10 +14,12 @@ module Enumerations
   class Configuration
     attr_accessor :primary_key
     attr_accessor :foreign_key_suffix
+    attr_accessor :translate
 
     def initialize
       @primary_key        = nil
       @foreign_key_suffix = nil
+      @translate          = true
     end
   end
 end

--- a/lib/enumerations/value.rb
+++ b/lib/enumerations/value.rb
@@ -66,6 +66,8 @@ module Enumerations
     end
 
     def translate_attribute(key, locale)
+      return @attributes[key].to_s unless Enumerations.configuration.translate
+
       I18n.t(key, scope: [:enumerations, self.class.name.demodulize.underscore, symbol],
                   default: @attributes[key].to_s,
                   locale: locale)

--- a/lib/enumerations/value.rb
+++ b/lib/enumerations/value.rb
@@ -66,7 +66,7 @@ module Enumerations
     end
 
     def translate_attribute(key, locale)
-      return @attributes[key].to_s unless Enumerations.configuration.translate
+      return @attributes[key].to_s unless Enumerations.configuration.translate_attributes
 
       I18n.t(key, scope: [:enumerations, self.class.name.demodulize.underscore, symbol],
                   default: @attributes[key].to_s,

--- a/lib/enumerations/version.rb
+++ b/lib/enumerations/version.rb
@@ -1,3 +1,3 @@
 module Enumerations
-  VERSION = '2.3.3'.freeze
+  VERSION = '2.4.0'.freeze
 end

--- a/test/translation_test.rb
+++ b/test/translation_test.rb
@@ -91,4 +91,13 @@ class TranslationTest < Minitest::Test
 
     assert_nil status
   end
+
+  def test_turn_of_translate
+    status = Status.find(:draft)
+    Enumerations.configuration.translate = false
+    name = status.name
+    Enumerations.configuration.translate = true
+
+    assert_equal name, 'Draft'
+  end
 end

--- a/test/translation_test.rb
+++ b/test/translation_test.rb
@@ -94,9 +94,9 @@ class TranslationTest < Minitest::Test
 
   def test_turn_of_translate
     status = Status.find(:draft)
-    Enumerations.configuration.translate = false
+    Enumerations.configuration.translate_attributes = false
     name = status.name
-    Enumerations.configuration.translate = true
+    Enumerations.configuration.translate_attributes = true
 
     assert_equal name, 'Draft'
   end


### PR DESCRIPTION
We have an application where I18n backend is active record. This means everytime we access an attribute it does an SQL query.

We need a way to disable this feature entirely.