### PR TITLE
Add configuration to suppress invalid value error

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ Or you can set enumerations by `symbol`:
 @post.status = Status.find(:draft)
 ```
 
-> If you try to set value that is not an Enumeration value (except `nil`), you will get an `Enumerations::InvalidValueError` exception.
+> If you try to set value that is not an Enumeration value (except `nil`), you will get an `Enumerations::InvalidValueError` exception. You can turn this exception off in configuration.
 
 Also, you can set enumeration value like this:
 
@@ -297,8 +297,8 @@ Configuration
 
 Basically no configuration is needed.
 
-**Enumerations** has two configuration options.
-You can customize primary key and foreign key suffix.
+**Enumerations** has four configuration options.
+You can customize primary key, foreign key suffix, whether to translate attributes and whether to raise `Enumerations::InvalidValueError` exception when setting invalid values.
 Just add initializer file to `config/initializers/enumerations.rb`.
 
 Example of configuration:
@@ -307,9 +307,10 @@ Example of configuration:
 # config/initializers/enumerations.rb
 
 Enumerations.configure do |config|
-  config.primary_key          = :id
-  config.foreign_key_suffix   = :id
-  config.translate_attributes = true
+  config.primary_key               = :id
+  config.foreign_key_suffix        = :id
+  config.translate_attributes      = true
+  config.raise_invalid_value_error = true
 end
 ```
 

--- a/README.md
+++ b/README.md
@@ -230,6 +230,32 @@ Use in forms:
   = f.collection_select :status, Status.all, :symbol, :name
 ```
 
+
+
+## Validating input
+
+Enumerations will by default raise an exception if you try to set an invalid value. This prevents usage of validations, which you might want to add if you're developing an API and have to return meaningful errors to API clients.
+
+You can enable validations by first disabling error raising on invalid input (see [configuration](#configuration)). Then, you should add an inclusion validation to enumerated attributes:
+```ruby
+class Post < ActiveRecord::Base
+  enumeration :status
+
+  validates :status, inclusion: { in: Status.all }
+end
+```
+
+You'll now get an appropriate error message when you insert an invalid value:
+```ruby
+> post = Post.new(status: 'invalid')
+> post.valid?
+=> false
+> post.errors.full_messages.to_sentence
+=> "Status is not included in the list"
+> post.status
+=> "invalid"
+```
+
 Advanced Usage
 =====
 

--- a/lib/enumerations/configuration.rb
+++ b/lib/enumerations/configuration.rb
@@ -17,11 +17,13 @@ module Enumerations
     attr_accessor :primary_key
     attr_accessor :foreign_key_suffix
     attr_accessor :translate_attributes
+    attr_accessor :raise_invalid_value_error
 
     def initialize
-      @primary_key          = nil
-      @foreign_key_suffix   = nil
-      @translate_attributes = true
+      @primary_key               = nil
+      @foreign_key_suffix        = nil
+      @translate_attributes      = true
+      @raise_invalid_value_error = true
     end
   end
 end

--- a/lib/enumerations/version.rb
+++ b/lib/enumerations/version.rb
@@ -1,3 +1,3 @@
 module Enumerations
-  VERSION = '2.4.0'.freeze
+  VERSION = '2.5.0'.freeze
 end

--- a/test/enumerations_test.rb
+++ b/test/enumerations_test.rb
@@ -133,6 +133,20 @@ class EnumerationsTest < Minitest::Test
     end
   end
 
+  def test_nonexistent_value_assignment_with_error_raising_turned_off
+    Enumerations.configuration.raise_invalid_value_error = false
+
+    user = User.new(role: :nonexistent_value)
+
+    assert_equal user.role, 'nonexistent_value'
+
+    user.role = :other_nonexistent_value
+
+    assert_equal user.role, 'other_nonexistent_value'
+
+    Enumerations.configuration.raise_invalid_value_error = true
+  end
+
   def test_on_nil_value_assignment
     user = User.new(role: nil)
     assert_nil user.role


### PR DESCRIPTION
This PR adds optional configuration for suppressing `Enumerations::InvalidValueError`.

New configuration option can be found under the `Enumerations.configuration.raise_invalid_value_error` property. It's set to `true` by default making this change backward-compatible.