### PR TITLE
Add Ruby 3 support

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,23 @@
+name: Test suite
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  test:
+    runs-on: ubuntu-18.04
+    strategy:
+      matrix:
+        ruby: [2.6, 2.7, 3.0]
+
+    steps:
+      - uses: actions/checkout@v2
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ matrix.ruby }}
+          bundler-cache: true
+      - name: Ruby ${{ matrix.ruby }}
+        run: bundle exec rake test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,6 +8,7 @@ on:
 
 jobs:
   test:
+    name: Ruby ${{ matrix.ruby }}
     runs-on: ubuntu-18.04
     strategy:
       matrix:
@@ -19,5 +20,5 @@ jobs:
         with:
           ruby-version: ${{ matrix.ruby }}
           bundler-cache: true
-      - name: Ruby ${{ matrix.ruby }}
+      - name: Run tests
         run: bundle exec rake test

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Change Log
 
+## [v2.5.1](https://github.com/infinum/enumerations/tree/v2.5.1) (YYYY-MM-DD)
+[Full Changelog](https://github.com/infinum/enumerations/compare/v2.5.0...v2.5.1)
+
+**Implemented enhancements:**
+
+- Add support for Ruby 3 [\#52](https://github.com/infinum/enumerations/issues/52)
+
+## [v2.5.0](https://github.com/infinum/enumerations/tree/v2.5.0) (2021-03-03)
+[Full Changelog](https://github.com/infinum/enumerations/compare/v2.4.0...v2.5.0)
+
+**Implemented enhancements:**
+
+- Add `raise_invalid_value_error` configuration option to disable raising errors on invalid values
+
 ## [v2.4.0](https://github.com/infinum/enumerations/tree/v2.4.0) (2019-02-07)
 [Full Changelog](https://github.com/infinum/enumerations/compare/v2.3.3...v2.4.0)
 

--- a/lib/enumerations/finder_methods.rb
+++ b/lib/enumerations/finder_methods.rb
@@ -31,7 +31,7 @@ module Enumerations
     #   Role.find_by(name: 'Admin') => #<Enumerations::Value: @base=Role, @symbol=:admin...>
     #
     def find_by(**args)
-      where(args).first
+      where(**args).first
     end
 
     def find_by_key(key)

--- a/lib/enumerations/value.rb
+++ b/lib/enumerations/value.rb
@@ -102,7 +102,7 @@ module Enumerations
       @attributes.each do |key, _|
         method_name = "#{key}?"
 
-        next if respond_to?(method_name.to_sym)
+        next if self.class.instance_methods(false).include?(method_name.to_sym)
 
         self.class.send :define_method, method_name do
           @attributes[key].present?

--- a/lib/enumerations/value.rb
+++ b/lib/enumerations/value.rb
@@ -54,7 +54,7 @@ module Enumerations
     #
     def define_attributes_getters
       @attributes.each do |key, _|
-        next if respond_to?(key)
+        next if self.class.instance_methods(false).include?(key)
 
         self.class.send :define_method, key do |locale: I18n.locale|
           case @attributes[key]

--- a/lib/enumerations/value.rb
+++ b/lib/enumerations/value.rb
@@ -54,7 +54,7 @@ module Enumerations
     #
     def define_attributes_getters
       @attributes.each do |key, _|
-        next if self.class.instance_methods(false).include?(key)
+        next if self.class.method_defined?(key)
 
         self.class.send :define_method, key do |locale: I18n.locale|
           case @attributes[key]
@@ -102,7 +102,7 @@ module Enumerations
       @attributes.each do |key, _|
         method_name = "#{key}?"
 
-        next if self.class.instance_methods(false).include?(method_name.to_sym)
+        next if self.class.method_defined?(method_name.to_sym)
 
         self.class.send :define_method, method_name do
           @attributes[key].present?

--- a/lib/enumerations/version.rb
+++ b/lib/enumerations/version.rb
@@ -1,3 +1,3 @@
 module Enumerations
-  VERSION = '2.5.0'.freeze
+  VERSION = '2.5.1'.freeze
 end


### PR DESCRIPTION
Fixes Ruby 3 deprecations and keeps backward compatibility for currently supported Rubies. I tested this locally on Ruby 3.0.1, but CI probably needs to be updated with the latest Ruby version.

Closes #52 