### PR TITLE
Initialize ActiveSupport::Multibyte::Chars with a String

### DIFF
--- a/lib/enumerations/base.rb
+++ b/lib/enumerations/base.rb
@@ -126,7 +126,7 @@ module Enumerations
     attr_reader :symbol, :attributes
 
     def initialize(symbol, attributes)
-      super(symbol)
+      super(symbol.to_s)
 
       @symbol = symbol
       @attributes = attributes

--- a/test/enumerations_test.rb
+++ b/test/enumerations_test.rb
@@ -26,6 +26,12 @@ class EnumerationsTest < Minitest::Test
     assert_equal 'draft', p.status.to_s
   end
 
+  def test_model_uniqueness_validation
+    p = Post.new(status: :draft)
+
+    assert_equal true, p.valid?
+  end
+
   def test_model_bang_assignment_with_custom_name
     p = Post.new
     p.different_status_draft!

--- a/test/helpers/test_helper.rb
+++ b/test/helpers/test_helper.rb
@@ -32,6 +32,8 @@ end
 class Post < ActiveRecord::Base
   enumeration :status
   enumeration :different_status, foreign_key: :some_other_status, class_name: 'Status'
+
+  validates :status, uniqueness: true
 end
 
 class User < ActiveRecord::Base

--- a/test/value_test.rb
+++ b/test/value_test.rb
@@ -82,4 +82,22 @@ class ValueTest < Minitest::Test
 
     assert_equal status.name?, false
   end
+
+  def test_enumeration_raises_error_for_nonexistent_attribute
+    enum = Class.new(Enumerations::Base) do
+      value :foobar
+    end
+
+    assert_raises NoMethodError do
+      enum.foobar.name
+    end
+  end
+
+  def test_enumeration_does_not_respond_to_nonexistent_attribute
+    enum = Class.new(Enumerations::Base) do
+      value :foobar
+    end
+
+    assert_equal enum.foobar.respond_to?(:name), false
+  end
 end


### PR DESCRIPTION
Casts enumeration value symbol to String before passing it to [`ActiveSupport::Multibyte::Chars`](https://github.com/rails/rails/blob/main/activesupport/lib/active_support/multibyte/chars.rb) (fixes https://github.com/infinum/enumerations/issues/55). `Chars` should be initialized with a string, but it has so far been initialized with a symbol, which caused the referenced issue.

Adds regression tests for https://github.com/infinum/enumerations/issues/55 and https://github.com/infinum/enumerations/issues/42.