### PR TITLE
Return stored enumeration instances as-is from attribute getters

### DIFF
--- a/lib/enumerations/value.rb
+++ b/lib/enumerations/value.rb
@@ -58,6 +58,7 @@ module Enumerations
 
         self.class.send :define_method, key do |locale: I18n.locale|
           case @attributes[key]
+          when Enumerations::Base then @attributes[key]
           when String, Symbol then translate_attribute(key, locale)
           else @attributes[key]
           end

--- a/test/value_test.rb
+++ b/test/value_test.rb
@@ -108,4 +108,13 @@ class ValueTest < Minitest::Test
 
     assert_equal enum.foobar.upcase, 'FOOBAR'
   end
+
+  def test_enumeration_attribute_storing_another_enumeration_is_returned_as_is
+    enum = Class.new(Enumerations::Base) do
+      value :foobar, related: Role.admin
+    end
+
+    assert_instance_of Role, enum.foobar.related
+    assert_equal true, enum.foobar.related.admin?
+  end
 end


### PR DESCRIPTION
Since 3.0 `Enumerations::Base` inherits from `String`. In `define_attributes_getters` the `when String, Symbol` branch now also matches an enum instance stored as another enum's attribute (it *is* a `String` now), routing it through `translate_attribute` and returning a plain `String` instead of the enum instance.

So an attribute that stores another enumeration:

```ruby
class Product < Enumerations::Base
  value :basic, name: 'Basic', active: true
end

class Price < Enumerations::Base
  value :basic_monthly, product: Product.basic
end

Price.basic_monthly.product        # => "basic" (a String, was a Product before 3.0)
Price.basic_monthly.product.active # => NoMethodError: undefined method 'active' for an instance of String
```

Added a `when Enumerations::Base` branch before the `String`/`Symbol` branch so the stored instance is returned as-is. Order matters since `Base < String`. Also added a regression test.